### PR TITLE
Allows user to set the menu ordering in WordPress sidebar

### DIFF
--- a/framework/Panel.php
+++ b/framework/Panel.php
@@ -79,9 +79,7 @@ class Panel {
             function () use ($attrs)
             {
                 $this->plugin->controller->call($attrs['uses']);
-            },
-	        $icon,
-	        isset($attrs['position']) ? $attrs['position'] : null
+            }, $icon
         );
     }
 

--- a/framework/Panel.php
+++ b/framework/Panel.php
@@ -79,7 +79,9 @@ class Panel {
             function () use ($attrs)
             {
                 $this->plugin->controller->call($attrs['uses']);
-            }, $icon
+            }, 
+            $icon,
+            isset($attrs['position']) ? $attrs['position'] : null
         );
     }
 

--- a/framework/Panel.php
+++ b/framework/Panel.php
@@ -79,7 +79,9 @@ class Panel {
             function () use ($attrs)
             {
                 $this->plugin->controller->call($attrs['uses']);
-            }, $icon
+            },
+	        $icon,
+	        isset($attrs['position']) ? $attrs['position'] : null
         );
     }
 


### PR DESCRIPTION
Added the position for the panel. This allows developer to set the menu ordering in WordPress sidebar.

For example:

``` php
    $plugin->panel->add([
        'type' => 'panel',
        'as' => 'mainPanel',
        'title' => 'My Plugin Panel',
        'slug' => 'my-plugin-panel',
        'icon' => 'dashicons-list-view',
        'position' => '100.11', // added position
    ], 'AdminController@index');
```

Reference: http://codex.wordpress.org/Function_Reference/add_menu_page
