### PR TITLE
Update Shortcode.php

### DIFF
--- a/framework/Shortcode.php
+++ b/framework/Shortcode.php
@@ -34,7 +34,7 @@ class Shortcode {
                 $atts = $this->renameArguments($args, $atts);
             }
 
-            call_user_func_array([$this->api, $fn], $atts);
+            return call_user_func_array([$this->api, $fn], $atts);
         });
     }
 


### PR DESCRIPTION
Now the shortcode is executed and placed inside a post. Without the "return" statement before the call_user_func_array the function was correctly executed but no output was given (note that the only way to show the code rendered by the shortcode without the return statement was to directly show it inside the function, causing the code to be placed right upon the post, without considering the shortcode position).
